### PR TITLE
Encrypting SO Tokens before setting them up as cookies

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -8,16 +8,9 @@ organization:
 stackoverflow:
   baseUrl: ${STACK_OVERFLOW_INSTANCE_URL}
   # teamName: ${STACK_OVERFLOW_TEAM_NAME}
-  apiAccessToken: ${STACK_OVERFLOW_ENTERPRISE_ACCESS_TOKEN}
+  apiAccessToken: ${STACK_OVERFLOW_API_ACCESS_TOKEN}
   clientId: ${STACK_OVERFLOW_CLIENT_ID}
-  teamName: moises-test-team
-  redirectUri: http://redirectmeto.com/http://localhost:3000/stack-overflow-teams/
-  schedule:
-    {
-      frequency: { minutes: 20 },
-      timeout: { minutes: 5 },
-      initialDelay: { seconds: 3 },
-    }
+  redirectUri: ${STACK_OVERFLOW_REDIRECT_URI}
 
 backend:
   # Used for enabling authentication, secret is shared by all backend plugins

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -10,6 +10,7 @@ stackoverflow:
   # teamName: ${STACK_OVERFLOW_TEAM_NAME}
   apiAccessToken: ${STACK_OVERFLOW_ENTERPRISE_ACCESS_TOKEN}
   clientId: ${STACK_OVERFLOW_CLIENT_ID}
+  teamName: moises-test-team
   redirectUri: http://redirectmeto.com/http://localhost:3000/stack-overflow-teams/
   schedule:
     {

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -16,7 +16,10 @@ import {
 } from '@backstage/plugin-search-react';
 import { CatalogIcon, Content, Header, Page } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
-import { StackOverflowIcon, StackOverflowSearchResultListItem } from 'backstage-plugin-stack-overflow-teams';
+import {
+  StackOverflowIcon,
+  StackOverflowSearchResultListItem,
+} from 'backstage-plugin-stack-overflow-teams';
 
 const useStyles = makeStyles((theme: Theme) => ({
   bar: {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -57,7 +57,7 @@ backend.add(import('@backstage/plugin-kubernetes-backend'));
 
 // StackOverflow
 
-backend.add(import('backstage-plugin-stack-overflow-teams-backend'));
+backend.add(import('backstage-plugin-stack-overflow-teams-backend')); // Teams Backend
+backend.add(import('backstage-stack-overflow-teams-collator')); // Optional questions collator
 
-backend.add(import('backstage-stack-overflow-teams-collator'));
 backend.start();

--- a/plugins/search-backend-module-stack-overflow-teams-collator/README.md
+++ b/plugins/search-backend-module-stack-overflow-teams-collator/README.md
@@ -13,7 +13,7 @@ To use any of the functionality this plugin provides, you need to start by confi
 
 ```yaml
 stackoverflow:
-  baseUrl: https://stackoverflowteams.com # alternative: your Stack Overflow Enterprise site
+  baseUrl: https://api.stackoverflowteams.com # alternative: your Stack Overflow Enterprise site
   teamName: $STACK_OVERFLOW_TEAM_NAME # optional if you are on Enterprise
   apiAccessToken: $STACK_OVERFLOW_API_ACCESS_TOKEN
 ```

--- a/plugins/search-backend-module-stack-overflow-teams-collator/package.json
+++ b/plugins/search-backend-module-stack-overflow-teams-collator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-stack-overflow-teams-collator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A module for the search backend that exports stack overflow for teams modules",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/stack-overflow-teams-backend/README.md
+++ b/plugins/stack-overflow-teams-backend/README.md
@@ -6,109 +6,56 @@ Backend counterpart of the Stack Overflow for Teams Plugin.
 
 The **Stack Overflow for Teams Backend plugin** is responsible for:
 
-  
-
--  **Indexing all questions** from the private Stack Overflow instance (an enhanced version of the existing community plugins in the Backstage repository).
-
--  **Handling API requests** via ``createStackOverflowApi`` and ``createStackOverflowService`` to the Stack Overflow instance for retrieving:
-
--  `/users`
-
--  `/tags`
-
--  `/questions`
-
-- Posting new questions via `/questions`
-
--  **Managing OAuth authentication flow** to securely access Stack Overflow private instances via ``createStackOverflowAuth``
-
-  
+- **Indexing all questions** from the private Stack Overflow instance (an enhanced version of the existing community plugins in the Backstage repository).
+- **Handling API requests** via ``createStackOverflowApi`` and ``createStackOverflowService`` to the Stack Overflow instance for retrieving:
+  - `/users`
+  - `/tags`
+  - `/questions`
+  - Posting new questions via `/questions`
+- **Managing OAuth authentication flow** to securely access Stack Overflow private instances via ``createStackOverflowAuth``
+- **Encrypts** the Stack Overflow Token before sending it as an http-only cookie to the frontend.
 
 ## OAuth Authentication Flow
 
-  
-
-The backend is the only component that directly utilizes **Stack Overflow access tokens** for requests.
-
-  
+The backend is the only component that directly utilizes the **encrypted Stack Overflow access tokens** for requests.
 
 ### **Authorization Flow Details**
-
-  
-
-![image](https://github.com/user-attachments/assets/1a7df089-c3c6-49a4-8761-38479e89214a)
-
-  
 
 #### **`/auth/start`**
 
 - Generates **PKCE Code Verifier**.
-
 - Hashes Code Verifier to obtain **Code Challenge**.
-
 - Generates a **state** (random string).
-
 - Stores **Code Verifier** and **State** in a **secure, HTTP-only cookie** accessible only to the server.
-
-  
 
 #### **`/callback`**
 
 - Retrieves the stored **Code Verifier** and **State**.
-
 - Validates that the received **state** matches the one from Stack Overflow's query string parameter.
-
 - The backend requests an **Access Token** using the stored **Code Verifier**.
-
-- Stores the **Stack Overflow Access Token** in a **secure, HTTP-only cookie**.
-
-  
-  
+- Backend **encrypts the token**, using the JWT secret stored in memory.
+- Stores the **encrypted Stack Overflow Access Token** in a **secure, HTTP-only cookie**.
 
 ## Installation
 
-  
-
 This plugin is installed via the `backstage-plugin-stack-overflow-teams-backend` package. To install it to your backend package, run the following command:
 
-  
-
 ```bash
-
-# From your root directory
-
-yarn  --cwd  packages/backend  add  backstage-plugin-stack-overflow-teams-backend
-
+yarn --cwd packages/backend add backstage-plugin-stack-overflow-teams-backend
 ```
-
-  
 
 Then add the plugin to your backend in `packages/backend/src/index.ts`:
 
-  
-
 ```ts
-
-const backend =  createBackend();
+const backend = createBackend();
 
 // ...
 
 backend.add(import('backstage-plugin-stack-overflow-teams-backend'));
-
 ```
-
-  
 
 ## Development
 
-  
-
-This plugin backend can be started in a standalone mode from directly in this
-
-package with `yarn start`. It is a limited setup that is most convenient when
-
-developing the plugin backend itself.
-
-  
+This plugin backend can be started in a standalone mode from directly in this package with `yarn start`. It is a limited setup that is most convenient when developing the plugin backend itself.
 
 If you want to run the entire project, including the frontend, run `yarn dev` from the root directory.

--- a/plugins/stack-overflow-teams-backend/package.json
+++ b/plugins/stack-overflow-teams-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-stack-overflow-teams-backend",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/stack-overflow-teams-backend/package.json
+++ b/plugins/stack-overflow-teams-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-stack-overflow-teams-backend",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -42,6 +42,7 @@
     "@backstage/plugin-search-common": "^1.2.17",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
+    "jsonwebtoken": "^9.0.2",
     "qs": "^6.14.0",
     "zod": "^3.22.4"
   },
@@ -49,6 +50,7 @@
     "@backstage/backend-test-utils": "^1.2.0",
     "@backstage/cli": "^0.29.4",
     "@types/express": "^4.17.6",
+    "@types/jsonwebtoken": "^9",
     "@types/qs": "^6",
     "@types/supertest": "^2.0.12",
     "msw": "^2.7.3",

--- a/plugins/stack-overflow-teams-backend/src/plugin.ts
+++ b/plugins/stack-overflow-teams-backend/src/plugin.ts
@@ -2,6 +2,7 @@ import {
   coreServices,
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
+import { randomBytes } from 'crypto'
 import { createRouter } from './router';
 import { createStackOverflowService } from './services/StackOverflowService';
 import { StackOverflowConfig } from './services/StackOverflowService';
@@ -11,6 +12,9 @@ import { StackOverflowConfig } from './services/StackOverflowService';
  *
  * @public
  */
+
+const JWT_SECRET = randomBytes(64).toString('hex')
+
 export const stackOverflowTeamsPlugin = createBackendPlugin({
   pluginId: 'stack-overflow-teams',
   register(env) {
@@ -38,6 +42,7 @@ export const stackOverflowTeamsPlugin = createBackendPlugin({
             stackOverflowConfig,
             logger,
             stackOverflowService,
+            jwtSecret: JWT_SECRET
           }),
         );
       },

--- a/plugins/stack-overflow-teams-backend/src/router.ts
+++ b/plugins/stack-overflow-teams-backend/src/router.ts
@@ -206,11 +206,11 @@ export async function createRouter({
           .json({ error: 'Missing Stack Overflow Teams Access Token' });
       }
       const questions = await stackOverflowService.getQuestions(authToken);
-      res.send(questions);
+      return res.send(questions);
     } catch (error: any) {
       // Fix type issue when including the error for some reason
       logger.error('Error fetching questions', { error });
-      res.status(500).send({
+      return res.status(500).send({
         error: `Failed to fetch questions from the Stack Overflow instance`,
       });
     }
@@ -225,11 +225,11 @@ export async function createRouter({
           .json({ error: 'Missing Stack Overflow Teams Access Token' });
       }
       const tags = await stackOverflowService.getTags(authToken);
-      res.send(tags);
+      return res.send(tags);
     } catch (error: any) {
       // Fix type issue when including the error for some reason
       logger.error('Error fetching tags', { error });
-      res.status(500).send({
+      return res.status(500).send({
         error: `Failed to fetch tags from the Stack Overflow instance`,
       });
     }
@@ -244,11 +244,11 @@ export async function createRouter({
           .json({ error: 'Missing Stack Overflow Teams Access Token' });
       }
       const users = await stackOverflowService.getUsers(authToken);
-      res.send(users);
+      return res.send(users);
     } catch (error: any) {
       // Fix type issue when including the error for some reason
       logger.error('Error fetching users', { error });
-      res.status(500).send({
+      return res.status(500).send({
         error: `Failed to fetch users from the Stack Overflow instance`,
       });
     }

--- a/plugins/stack-overflow-teams-backend/src/utils/index.ts
+++ b/plugins/stack-overflow-teams-backend/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './jwtUtils'

--- a/plugins/stack-overflow-teams-backend/src/utils/jwtUtils.ts
+++ b/plugins/stack-overflow-teams-backend/src/utils/jwtUtils.ts
@@ -1,0 +1,14 @@
+import jwt from 'jsonwebtoken'
+
+export const encryptToken = (token: string, secret: string): string  => {
+    return jwt.sign({token}, secret, {expiresIn: '24h'})
+} 
+
+export const decryptToken = (token: string, secret: string): string | null => {
+    try {
+        const decoded = jwt.verify(token, secret) as { token: string };
+        return decoded.token;
+    } catch (error: any) {
+        return null
+    }
+}

--- a/plugins/stack-overflow-teams/README.md
+++ b/plugins/stack-overflow-teams/README.md
@@ -1,11 +1,10 @@
-
 # Stack Overflow Teams Frontend Plugin
 
 This package is the **frontend component** of the `stack-overflow-teams` plugin for Backstage.
 
 ## Areas of Responsibility
 
- It provides the UI and interacts with the [backend service](https://github.com/EstoesMoises/backstage-stackoverflow/tree/main/plugins/stack-overflow-teams-backend) to fetch data from your Stack Overflow Enterprise instance.
+It provides the UI and interacts with the [backend service](https://github.com/EstoesMoises/backstage-stackoverflow/tree/main/plugins/stack-overflow-teams-backend) to fetch data from your Stack Overflow Enterprise instance.
 
 ### Backend Dependency
 
@@ -13,120 +12,80 @@ To fully utilize this plugin, you must also install and configure the correspond
 
 ## More details
 
-
 ### Enhanced `<StackOverflowSearchResultListItem />`
 
-This component, is a modified version of the [community plugin.](https://github.com/backstage/community-plugins/tree/main/workspaces/stack-overflow/plugins/stack-overflow/src/search/StackOverflowSearchResultListItem) 
+This component is a modified version of the [community plugin.](https://github.com/backstage/community-plugins/tree/main/workspaces/stack-overflow/plugins/stack-overflow/src/search/StackOverflowSearchResultListItem)
 
-It adds a more Stack Overflow like interface, adding more information such as the questions' score, user role, user reputation and timestamp for the questions.
-
+It adds a more Stack Overflow-like interface, including additional information such as the questions' score, user role, user reputation, and timestamp.
 
 ---
 
 ### Individual Frontend Components
 
+- **`<StackOverflowMe />`**
   
+  Displays information about the authenticated user.
 
--  **`<StackOverflowMe />`**
-
-Displays information about the authenticated user.
-
+- **`<StackOverflowPostQuestionModal />`**
   
+  Provides a form for users to create a new Stack Overflow question. Once submitted, an API request is executed to create the question.
+  
+  This form listens to the `'openAskQuestionModal'` event. You can utilize this anywhere in your Backstage UI. To invoke the form, add the component to your UI along with a button that dispatches the event. Example:
 
--  **`<StackOverflowPostQuestionModal />`**
-
-Provides a form for users to create a new Stack Overflow question. Once submitted, an API request is executed to create the question.
-
-This form listens to the `'openAskQuestionModal'` event. You can utilize this anywhere in you Backstage UI, to invoque the form you must add the component to your UI, but also a button that dispatches the event. E.g.:
-
-    <SidebarItem
-    
+  ```tsx
+  <SidebarItem
     icon={StackOverflowIcon}
-    
-    onClick={() =>  window.dispatchEvent(new  Event('openAskQuestionModal'))}
-    
+    onClick={() => window.dispatchEvent(new Event('openAskQuestionModal'))}
     text="Ask a Question"
-    
-    />
-    
-    <StackOverflowPostQuestionModal  />
-
+  />
   
+  <StackOverflowPostQuestionModal />
+  ```
 
--  **`<StackOverflowQuestion />`**
-
-Retrieves questions from the API. Uses standard pagination, displaying only the first 30 API results.
-
+- **`<StackOverflowQuestion />`**
   
+  Retrieves questions from the API. Uses standard pagination, displaying only the first 30 API results.
 
--  **`<StackOverflowTags />`**
-
-Retrieves tags from the API. Uses standard pagination, displaying only the first 30 API results.
-
+- **`<StackOverflowTags />`**
   
+  Retrieves tags from the API. Uses standard pagination, displaying only the first 30 API results.
 
--  **`<StackOverflowUsers />`**
-
-Retrieves users from the API. Uses standard pagination, displaying only the first 30 API results.
-
--  **`<StackOverflowHub />`**
-
-The below various components collectively create this informative hub.
-
+- **`<StackOverflowUsers />`**
   
+  Retrieves users from the API. Uses standard pagination, displaying only the first 30 API results.
+
+- **`<StackOverflowHub />`**
+  
+  Various components collectively create this informative hub.
 
 ## Authentication Components
 
+- **`<StackAuthStart />`**
   
+  Initiates **`/auth/start`** on the backend.
 
--  **`<StackAuthStart />`**
-
-Initiates **`/auth/start`** on the backend.
-
+- **`<StackAuthLoading />`**
   
+  Handles the loading state during authentication.
 
--  **`<StackAuthLoading />`**
-
-Handles loading state during authentication.
-
+- **`<StackAuthCallback />`**
   
+  Receives the code and state from your Stack Overflow Enterprise instance as part of the OAuth process and initiates **`/callback`** in the backend.
 
--  **`<StackAuthCallback />`**
-
-Receives the code and state from your Stack Overflow Enterprise instance as part of the OAuth process and initiates **`/callback`** in the backend.
-
+- **`<StackAuthSuccess />`**
   
+  Displays authentication success state.
 
--  **`<StackAuthSuccess />`**
-
-Displays authentication success state.
-
+- **`<StackAuthFailed />`**
   
-
--  **`<StackAuthFailed />`**
-
-Displays authentication failure state.
-
-  
+  Displays authentication failure state.
 
 ### Page
 
+- **`<StackOverflowTeamsPage />`**
   
-
--  **`<StackOverflowTeamsPage />`**
-
-  
-
-This page triggers authentication components, it bundles and orchestrates everything for you so you don't have to use the authentication components separated. If authenticated, it will return the `<StackOverflowHub />`.
-
-  
+  This page triggers authentication components, bundles, and orchestrates everything for you so you don't have to use the authentication components separately. If authenticated, it will return the `<StackOverflowHub />`.
 
 ### API Requests
 
-  
-
-The frontend plugin creates an API Ref for StackOverflow for Teams, which can be found under the `/api` folder. **All API requests from the frontend are directed to Backstage's backend**.
-
-  
-  
-
+The frontend plugin creates an API Ref for Stack Overflow for Teams, which can be found under the `/api` folder. **All API requests from the frontend are directed to Backstage's backend**.

--- a/plugins/stack-overflow-teams/package.json
+++ b/plugins/stack-overflow-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-stack-overflow-teams",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/stack-overflow-teams/package.json
+++ b/plugins/stack-overflow-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-stack-overflow-teams",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13835,6 +13835,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jsonwebtoken@npm:^9":
+  version: 9.0.9
+  resolution: "@types/jsonwebtoken@npm:9.0.9"
+  dependencies:
+    "@types/ms": "npm:*"
+    "@types/node": "npm:*"
+  checksum: 10c0/d754a7b65fc021b298fc94e8d7a7d71f35dedf24296ac89286f80290abc5dbb0c7830a21440ee9ecbb340efc1b0a21f5609ea298a35b874cae5ad29a65440741
+  languageName: node
+  linkType: hard
+
 "@types/jsonwebtoken@npm:^9.0.0":
   version: 9.0.7
   resolution: "@types/jsonwebtoken@npm:9.0.7"
@@ -16113,10 +16123,12 @@ __metadata:
     "@backstage/plugin-search-backend-node": "npm:^1.3.8"
     "@backstage/plugin-search-common": "npm:^1.2.17"
     "@types/express": "npm:^4.17.6"
+    "@types/jsonwebtoken": "npm:^9"
     "@types/qs": "npm:^6"
     "@types/supertest": "npm:^2.0.12"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
+    jsonwebtoken: "npm:^9.0.2"
     msw: "npm:^2.7.3"
     qs: "npm:^6.14.0"
     supertest: "npm:^6.2.4"


### PR DESCRIPTION
I was setting the http-only cookies containing the unencrypted token directly in the browser. I've changed this so that the token is encrypted (using JWT tokens). The JWT is dynamically generated on the backend server start (which shouldn't be an inconvenience at all). This only aims to give the backend the tools to encrypt and decrypt the token stored in the http-only cookie.

I believe this should make the plugin secure, as the plugin still depends on a valid Backstage authentication. It leverages the CSRF protections that come [natively from Backstage](https://backstage.io/docs/auth/)