### PR TITLE
Removed JWT tokens logic

### DIFF
--- a/plugins/stack-overflow-teams/README.md
+++ b/plugins/stack-overflow-teams/README.md
@@ -1,6 +1,6 @@
 # Stack Overflow Teams Frontend Plugin
 
-This package is the **frontend component** of the `stack-overflow-teams` plugin for Backstage.
+This package is the frontend counterpart of the `stack-overflow-teams` plugin for Backstage.
 
 ## Areas of Responsibility
 

--- a/plugins/stack-overflow-teams/package.json
+++ b/plugins/stack-overflow-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-stack-overflow-teams",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
I made a mistake in how I interpreted JWT; this didn't add any additional security to my implementation, so I'm rolling back that logic.

The current implementation is secure. Tokens are behind a **secure** and **same-site: strict** http-only cookie. 

This plugin is still behind the walls of Backstage's authentication system, which already utilizes best practices for CSRF protection.