### PR TITLE
feat: added support for Basic and Business tiers by allowing manual input of PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,33 @@ This image runs a Backstage instance pre-configured with the Stack Overflow for 
 
 ---
 
-### Required Environment Variables
+## 📦 Required Environment Variables
 
-| Variable                          | Description                                                                                                                                                                                                                     |
-|:----------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `STACK_OVERFLOW_INSTANCE_URL`     | The base URL of your Stack Overflow for Teams (Enterprise) instance.                                                                                                                     |
-| `STACK_OVERFLOW_API_ACCESS_TOKEN` | A **read-only, no-expiry** API access token generated for your Stack Overflow Enterprise instance. This token is used by the plugin's search collator to index questions into Backstage search. |
-| `STACK_OVERFLOW_CLIENT_ID`        | The OAuth Client ID from your Stack Overflow application. This is required to enable the secure question creation flow from within Backstage.                                             |
+### For **Enterprise** Customers:
+
+| Variable                          | Description                                                                                                                                                                                                                                                                                        |
+| :-------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `STACK_OVERFLOW_INSTANCE_URL`     | The base URL of your Stack Overflow for Teams (Enterprise) instance.                                                                                                                                                                                                                               |
+| `STACK_OVERFLOW_API_ACCESS_TOKEN` | A **read-only, no-expiry** API access token generated for your Stack Overflow Enterprise instance. This token is used by the plugin’s search collator to index questions into Backstage search.                                                                                                    |
+| `STACK_OVERFLOW_CLIENT_ID`        | The OAuth Client ID from your Stack Overflow application. This is required to enable the secure question creation flow from within Backstage.                                                                                                                                                      |
 | `STACK_OVERFLOW_REDIRECT_URI`     | The redirect URI where Stack Overflow should send users after completing the OAuth authentication flow. By default, this is `{app.baseUrl}/stack-overflow-teams`. For local development, you can use a redirect service like `http://redirectmeto.com/http://localhost:7007/stack-overflow-teams`. |
 
+---
+
+### For **Basic** and **Business** Customers:
+
+| Variable                          | Description                                                                                                              |
+| :-------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
+| `STACK_OVERFLOW_TEAM_NAME`        | The **team name** or **team slug** from your Stack Overflow for Teams account.                                           |
+| `STACK_OVERFLOW_API_ACCESS_TOKEN` | A **read-only, no-expiry** API access token generated for your Stack Overflow Teams instance. Used for indexing content. |
+
+📖 How to generate your API Access Token
+
+Basic and Business customers can follow the official Stack Overflow for Teams guide to create a Personal Access Token (PAT) for API authentication:
+
+👉 [Personal Access Tokens (PATs) for API Authentication](https://stackoverflowteams.help/en/articles/10908790-personal-access-tokens-pats-for-api-authentication)
+
+This token should have read-only access and no expiration to be used for indexing questions into Backstage search.
 
 ---
 

--- a/app-config.docker-local.yaml
+++ b/app-config.docker-local.yaml
@@ -12,16 +12,19 @@ organization:
 
 stackoverflow:
   baseUrl: ${STACK_OVERFLOW_INSTANCE_URL}
-  # teamName: ${STACK_OVERFLOW_TEAM_NAME}
+  # Required only for Enteprise Tier.
+
+  teamName: ${STACK_OVERFLOW_TEAM_NAME}
+  # Required only for Basic and Business Tiers. 
 
   apiAccessToken: ${STACK_OVERFLOW_API_ACCESS_TOKEN}
   # The API Access Token is used for the Questions' collator, a no-expiry, read-only token is recommended.
 
   clientId: ${STACK_OVERFLOW_CLIENT_ID}
-  # The clientid must be for an API Application with read-write access.
+  # The clientid must be for an API Application with read-write access. Only provide if you are using the Enterprise tier.
 
   redirectUri: ${STACK_OVERFLOW_REDIRECT_URI}
-  # If no redirectUri is specified this will return to https://<backstage-domain>/stack-overflow-teams
+  # If no redirectUri is specified this will return to https://<backstage-domain>/stack-overflow-teams. Only provide if you are using the Enterprise tier.
 
 backend:
   # Used for enabling authentication, secret is shared by all backend plugins

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -6,17 +6,20 @@ organization:
   name: My Company
 
 stackoverflow:
-  baseUrl: ${STACK_OVERFLOW_INSTANCE_URL}
-  # teamName: ${STACK_OVERFLOW_TEAM_NAME}
+  # baseUrl: ${STACK_OVERFLOW_INSTANCE_URL}
+  # Required only for Enteprise Tier.
+
+  teamName: ${STACK_OVERFLOW_TEAM_NAME}
+  # Required only for Basic and Business Tiers. 
 
   apiAccessToken: ${STACK_OVERFLOW_API_ACCESS_TOKEN}
   # The API Access Token is used for the Questions' collator, a no-expiry, read-only token is recommended.
 
   clientId: ${STACK_OVERFLOW_CLIENT_ID}
-  # The clientid must be for an API Application with read-write access.
+  # The clientid must be for an API Application with read-write access. Only provide if you are using the Enterprise tier.
 
   redirectUri: ${STACK_OVERFLOW_REDIRECT_URI}
-  # If no redirectUri is specified this will return to https://<backstage-domain>/stack-overflow-teams
+  # If no redirectUri is specified this will return to https://<backstage-domain>/stack-overflow-teams. Only provide if you are using the Enterprise tier.
 
 backend:
   # Used for enabling authentication, secret is shared by all backend plugins

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -18,10 +18,10 @@ stackoverflow:
   apiAccessToken: ${STACK_OVERFLOW_API_ACCESS_TOKEN}
   # The API Access Token is used for the Questions' collator, a no-expiry, read-only token is recommended.
 
-  # clientId: ${STACK_OVERFLOW_CLIENT_ID}
+  clientId: ${STACK_OVERFLOW_CLIENT_ID}
   # The clientid must be for an API Application with read-write access. Only provide if you are using the Enterprise tier.
 
-  # redirectUri: ${STACK_OVERFLOW_REDIRECT_URI}
+  redirectUri: ${STACK_OVERFLOW_REDIRECT_URI}
   # If no redirectUri is specified this will return to https://<backstage-domain>/stack-overflow-teams. Only provide if you are using the Enterprise tier.
 
 backend:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -5,8 +5,11 @@ app:
 organization:
   name: My Company
 
+# For Basic and Business tiers, only provide teamName and apiAccessToken
+# For Enterprise tier DO NOT provide teamName.
+
 stackoverflow:
-  # baseUrl: ${STACK_OVERFLOW_INSTANCE_URL}
+  baseUrl: ${STACK_OVERFLOW_INSTANCE_URL}
   # Required only for Enteprise Tier.
 
   teamName: ${STACK_OVERFLOW_TEAM_NAME}

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -18,10 +18,10 @@ stackoverflow:
   apiAccessToken: ${STACK_OVERFLOW_API_ACCESS_TOKEN}
   # The API Access Token is used for the Questions' collator, a no-expiry, read-only token is recommended.
 
-  clientId: ${STACK_OVERFLOW_CLIENT_ID}
+  # clientId: ${STACK_OVERFLOW_CLIENT_ID}
   # The clientid must be for an API Application with read-write access. Only provide if you are using the Enterprise tier.
 
-  redirectUri: ${STACK_OVERFLOW_REDIRECT_URI}
+  # redirectUri: ${STACK_OVERFLOW_REDIRECT_URI}
   # If no redirectUri is specified this will return to https://<backstage-domain>/stack-overflow-teams. Only provide if you are using the Enterprise tier.
 
 backend:

--- a/plugins/search-backend-module-stack-overflow-teams-collator/config.d.ts
+++ b/plugins/search-backend-module-stack-overflow-teams-collator/config.d.ts
@@ -20,9 +20,9 @@ export interface Config {
      */
     stackoverflow: {
       /**
-       * The base url of the Stack Overflow API used for the plugin
+       * The base url of the Stack Overflow API used for the plugin, if no BaseUrl is provided it will default to https://api.stackoverflowteams.com
        */
-      baseUrl: string;
+      baseUrl?: string;
   
       /**
        * The API Access Token to authenticate to Stack Overflow API Version 3
@@ -31,7 +31,7 @@ export interface Config {
       apiAccessToken: string;
   
       /**
-       * The name of the team for a Stack Overflow for Teams account
+       * The name of the team for a Stack Overflow for Teams account. When teamName is provided baseUrl will always be https://api.stackoverflowteams.com
        */
       teamName?: string;
   

--- a/plugins/search-backend-module-stack-overflow-teams-collator/src/collators/StackOverflowQuestionsCollatorFactory.ts
+++ b/plugins/search-backend-module-stack-overflow-teams-collator/src/collators/StackOverflowQuestionsCollatorFactory.ts
@@ -133,9 +133,9 @@ export class StackOverflowQuestionsCollatorFactory
   async *execute(): AsyncGenerator<StackOverflowDocument> {
     this.logger.info(`Retrieving data using Stack Overflow API Version 3`);
 
-    if (!this.baseUrl) {
-      this.logger.warn(
-        `No stackoverflow.baseUrl configured in your app-config.yaml defaulting to https://api.stackoverflowteams.com`,
+    if (!this.baseUrl && this.teamName) {
+      this.logger.info(
+        `Connecting to the Teams API at https://api.stackoverflowteams.com`,
       );
     }
 
@@ -153,12 +153,20 @@ export class StackOverflowQuestionsCollatorFactory
     let requestUrl;
 
     if (this.teamName) {
-      const basePath =
-        this.baseUrl === this.stackOverflowTeamsAPI ? '/v3' : '/api/v3';
-      requestUrl = `${this.baseUrl}${basePath}/teams/${this.teamName}/questions${params}`;
+      requestUrl = `${this.stackOverflowTeamsAPI}/v3/teams/${this.teamName}/questions${params}`;
     } else {
       requestUrl = `${this.baseUrl}/api/v3/questions${params}`;
     }
+
+    // The code below has been commented, it has potential compatiblity with Enterprise Private Teams but I haven't tested it and since Private Teams is not widely used I've decided to change the logic to prioritise the support for the Basic and Business Teams.
+
+    // if (this.teamName) {
+    //   const basePath =
+    //     this.baseUrl === this.stackOverflowTeamsAPI ? '/v3' : '/api/v3';
+    //   requestUrl = `${this.baseUrl}${basePath}/teams/${this.teamName}/questions${params}`;
+    // } else {
+    //   requestUrl = `${this.baseUrl}/api/v3/questions${params}`;
+    // }
 
     let page = 1;
     let totalPages = 1;

--- a/plugins/stack-overflow-teams-backend/config.d.ts
+++ b/plugins/stack-overflow-teams-backend/config.d.ts
@@ -33,17 +33,17 @@ export interface Config {
       apiAccessToken: string;
   
       /**
-       * The name of the team for a Stack Overflow for Teams account
+       * The name of the team for a Stack Overflow for Teams account, required for Basic and Business tiers.
        */
       teamName?: string;
 
       /**
-       * Client Id for the OAuth Application, required to use the Stack Overflow for Teams Hub and write actions.
+       * Client Id for the OAuth Application, required only for Stack Overflow Enterprise and write actions.
        */
-      clientId: number;
+      clientId?: number;
 
       /**
-       * RedirectUri for the OAuth Application, required to use the Stack Overflow for Teams Hub and write actions.
+       * RedirectUri for the OAuth Application, required only for Stack Overflow Enterprise and write actions.
        * 
        * This should be your Backstage application domain ending in the plugin's <StackOverflowTeamsPage /> route
        * If not specified this will got to your <app.baseUrl>/stack-overflow-teams

--- a/plugins/stack-overflow-teams-backend/package.json
+++ b/plugins/stack-overflow-teams-backend/package.json
@@ -40,6 +40,7 @@
     "@backstage/plugin-catalog-node": "^1.15.0",
     "@backstage/plugin-search-backend-node": "^1.3.8",
     "@backstage/plugin-search-common": "^1.2.17",
+    "csrf": "^3.1.0",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "jsonwebtoken": "^9.0.2",

--- a/plugins/stack-overflow-teams-backend/src/api/createStackOverflowApi.ts
+++ b/plugins/stack-overflow-teams-backend/src/api/createStackOverflowApi.ts
@@ -9,7 +9,7 @@ export const createStackOverflowApi = (baseUrl: string) => {
     pageSize?: number
   ): Promise<T> => {
     let url = teamName
-      ? `${baseUrl}/api/v3/teams/${teamName}${endpoint}`
+      ? `${baseUrl}/v3/teams/${teamName}${endpoint}`
       : `${baseUrl}/api/v3${endpoint}`;
 
     const queryParams = new URLSearchParams();

--- a/plugins/stack-overflow-teams-backend/src/plugin.ts
+++ b/plugins/stack-overflow-teams-backend/src/plugin.ts
@@ -22,13 +22,28 @@ export const stackOverflowTeamsPlugin = createBackendPlugin({
         config: coreServices.rootConfig,
       },
       async init({ logger, httpRouter, config }) {
-        const forceOriginUrl = (baseUrl: string) : string => `${new URL(baseUrl).origin}`
+        const forceOriginUrl = (baseUrl: string): string =>
+          `${new URL(baseUrl).origin}`;
+
+        const teamName = config.getOptionalString('stackoverflow.teamName');
+
+        // If teamName is provided, always use api.stackoverflowteams.com
+        const baseUrl = teamName
+          ? 'https://api.stackoverflowteams.com'
+          : forceOriginUrl(
+              config.getOptionalString('stackoverflow.baseUrl') ||
+                'https://api.stackoverflowteams.com',
+            );
+
         const stackOverflowConfig: StackOverflowConfig = {
-          baseUrl: forceOriginUrl(config.getOptionalString('stackoverflow.baseUrl') || 'https://api.stackoverflowteams.com'),
-          teamName: config.getOptionalString('stackoverflow.teamName'),
+          baseUrl,
+          teamName,
           clientId: config.getOptionalNumber('stackoverflow.clientId'),
-          redirectUri: config.getOptionalString('stackoverflow.redirectUri') || `${config.getString('app.baseUrl')}/stack-overflow-teams`
+          redirectUri:
+            config.getOptionalString('stackoverflow.redirectUri') ||
+            `${config.getString('app.baseUrl')}/stack-overflow-teams`,
         };
+
         const stackOverflowService = await createStackOverflowService({
           config: stackOverflowConfig,
           logger,
@@ -38,7 +53,7 @@ export const stackOverflowTeamsPlugin = createBackendPlugin({
           await createRouter({
             stackOverflowConfig,
             logger,
-            stackOverflowService
+            stackOverflowService,
           }),
         );
       },

--- a/plugins/stack-overflow-teams-backend/src/plugin.ts
+++ b/plugins/stack-overflow-teams-backend/src/plugin.ts
@@ -24,9 +24,9 @@ export const stackOverflowTeamsPlugin = createBackendPlugin({
       async init({ logger, httpRouter, config }) {
         const forceOriginUrl = (baseUrl: string) : string => `${new URL(baseUrl).origin}`
         const stackOverflowConfig: StackOverflowConfig = {
-          baseUrl: forceOriginUrl(config.getString('stackoverflow.baseUrl')),
+          baseUrl: forceOriginUrl(config.getOptionalString('stackoverflow.baseUrl') || 'https://api.stackoverflowteams.com'),
           teamName: config.getOptionalString('stackoverflow.teamName'),
-          clientId: config.getNumber('stackoverflow.clientId'),
+          clientId: config.getOptionalNumber('stackoverflow.clientId'),
           redirectUri: config.getOptionalString('stackoverflow.redirectUri') || `${config.getString('app.baseUrl')}/stack-overflow-teams`
         };
         const stackOverflowService = await createStackOverflowService({

--- a/plugins/stack-overflow-teams-backend/src/router.ts
+++ b/plugins/stack-overflow-teams-backend/src/router.ts
@@ -38,7 +38,7 @@ export async function createRouter({
     const cookiesToken = cookies['stackoverflow-access-token'];
 
     try {
-      const authToken = cookiesToken
+      const authToken = cookiesToken;
       if (!authToken) {
         res.clearCookie('stackoverflow-access-token');
         return null;
@@ -124,10 +124,10 @@ export async function createRouter({
 
       const baseUrl = stackOverflowConfig.baseUrl;
       const teamName = stackOverflowConfig.teamName;
-      
+
       // Use the team-specific API endpoint for basic and business teams
-      const userApiUrl = teamName 
-        ? `${baseUrl}/v3/teams/${teamName}/users/me` 
+      const userApiUrl = teamName
+        ? `${baseUrl}/v3/teams/${teamName}/users/me`
         : `${baseUrl}/api/v3/users/me`;
 
       const userResponse = await fetch(userApiUrl, {
@@ -159,33 +159,39 @@ export async function createRouter({
   router.post('/auth/token', async (req: Request, res: Response) => {
     try {
       const { accessToken } = req.body;
-      
+
       if (!accessToken || typeof accessToken !== 'string') {
-        return res.status(400).json({ error: 'Valid access token is required' });
+        return res
+          .status(400)
+          .json({ error: 'Valid access token is required' });
       }
-      
-      // Don't use authService here, use the config directly
+
       const baseUrl = stackOverflowConfig.baseUrl;
       const teamName = stackOverflowConfig.teamName;
-      
+
       // Use the team-specific API endpoint for basic and business teams
-      const validationUrl = teamName 
-        ? `${baseUrl}/v3/teams/${teamName}/users/me` 
+      const validationUrl = teamName
+        ? `${baseUrl}/v3/teams/${teamName}/users/me`
         : `${baseUrl}/api/v3/users/me`;
-      
+
       const validationResponse = await fetch(validationUrl, {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
-      
-      if (validationResponse.status === 401 || validationResponse.status === 403) {
+
+      if (
+        validationResponse.status === 401 ||
+        validationResponse.status === 403
+      ) {
         return res.status(401).json({ error: 'Invalid Stack Overflow token' });
       }
-      
+
       if (!validationResponse.ok) {
-        logger.error(`Token validation failed: ${await validationResponse.text()}`);
+        logger.error(
+          `Token validation failed: ${await validationResponse.text()}`,
+        );
         return res.status(500).json({ error: 'Failed to validate token' });
       }
-      
+
       return res
         .cookie('stackoverflow-access-token', accessToken, {
           httpOnly: true,
@@ -193,7 +199,6 @@ export async function createRouter({
           sameSite: 'strict',
         })
         .json({ ok: true, message: 'Stack Overflow token accepted' });
-        
     } catch (error: any) {
       logger.error('Error setting manual access token:', error);
       return res.status(500).json({ error: 'Internal Server Error' });
@@ -217,12 +222,19 @@ export async function createRouter({
   // Info routes
 
   router.get('/baseurl', async (_req: Request, res: Response) => {
-    const baseUrl = stackOverflowConfig.baseUrl;
     try {
-      res.json({ SOInstance: baseUrl });
+      const baseUrl = stackOverflowConfig.baseUrl;
+      const teamsAPIUrl = 'https://api.stackoverflowteams.com';
+      const teamsBaseUrl = `https://stackoverflowteams.com/c/${stackOverflowConfig.teamName}`; // Fixed URL to match your previous code
+
+      if (baseUrl === teamsAPIUrl) {
+        return res.json({ SOInstance: teamsBaseUrl, teamName: stackOverflowConfig.teamName });
+      }
+
+      return res.json({ SOInstance: baseUrl });
     } catch (error) {
       console.error('Error fetching Stack Overflow base URL:', error);
-      res
+      return res
         .status(500)
         .json({ error: 'Failed to fetch Stack Overflow base URL' });
     }

--- a/plugins/stack-overflow-teams-backend/src/services/StackOverflowService/createStackOverflowService.ts
+++ b/plugins/stack-overflow-teams-backend/src/services/StackOverflowService/createStackOverflowService.ts
@@ -17,21 +17,50 @@ export async function createStackOverflowService({
   config: StackOverflowConfig;
   logger: LoggerService;
 }): Promise<StackOverflowAPI> {
+  // LOGGER
+
   logger.info('Initializing Stack Overflow Service');
 
+  if (config.baseUrl && config.teamName) {
+    logger.warn(
+      "Please note that this integration is not compatible with Enterprise Private Teams. When stackoverflow.teamName is provided the baseUrl will always change to 'api.stackoverflowteams.com'",
+    );
+  }
+
   const { baseUrl, teamName } = config;
-  const api = createStackOverflowApi(baseUrl || 'https://api.stackoverflowteams.com');
+  const api = createStackOverflowApi(
+    baseUrl || 'https://api.stackoverflowteams.com',
+  );
 
   return {
     // GET
-    getQuestions: (authToken) => api.GET<PaginatedResponse<Question>>('/questions', authToken, teamName),
-    getTags: (authToken) => api.GET<PaginatedResponse<Tag>>('/tags', authToken, teamName),
-    getUsers: (authToken) => api.GET<PaginatedResponse<User>>('/users', authToken, teamName),
-    getMe: (authToken) => api.GET<User>('/users/me', authToken, teamName),
+    getQuestions: authToken =>
+      api.GET<PaginatedResponse<Question>>('/questions', authToken, teamName),
+    getTags: authToken =>
+      api.GET<PaginatedResponse<Tag>>('/tags', authToken, teamName),
+    getUsers: authToken =>
+      api.GET<PaginatedResponse<User>>('/users', authToken, teamName),
+    getMe: authToken => api.GET<User>('/users/me', authToken, teamName),
     // POST
-    postQuestions: (title: string, body: string, tags: string[], authToken: string) =>
-      api.POST<Question>('/questions', { title, body, tags }, authToken, teamName),
+    postQuestions: (
+      title: string,
+      body: string,
+      tags: string[],
+      authToken: string,
+    ) =>
+      api.POST<Question>(
+        '/questions',
+        { title, body, tags },
+        authToken,
+        teamName,
+      ),
     // SEARCH
-    getSearch: (query: string, authToken: string) => api.SEARCH<PaginatedResponse<SearchItem>>('/search', query, authToken, teamName)
+    getSearch: (query: string, authToken: string) =>
+      api.SEARCH<PaginatedResponse<SearchItem>>(
+        '/search',
+        query,
+        authToken,
+        teamName,
+      ),
   };
 }

--- a/plugins/stack-overflow-teams-backend/src/services/StackOverflowService/createStackOverflowService.ts
+++ b/plugins/stack-overflow-teams-backend/src/services/StackOverflowService/createStackOverflowService.ts
@@ -20,7 +20,7 @@ export async function createStackOverflowService({
   logger.info('Initializing Stack Overflow Service');
 
   const { baseUrl, teamName } = config;
-  const api = createStackOverflowApi(baseUrl);
+  const api = createStackOverflowApi(baseUrl || 'https://api.stackoverflowteams.com');
 
   return {
     // GET

--- a/plugins/stack-overflow-teams-backend/src/services/StackOverflowService/types.ts
+++ b/plugins/stack-overflow-teams-backend/src/services/StackOverflowService/types.ts
@@ -53,10 +53,10 @@ export type PaginatedResponse<T> = {
 };
 
 export type StackOverflowConfig = {
-  baseUrl: string;
+  baseUrl?: string;
   teamName?: string;
-  clientId: number;
-  redirectUri: string;
+  clientId?: number;
+  redirectUri?: string;
   authUrl?: string;
 };
 

--- a/plugins/stack-overflow-teams/package.json
+++ b/plugins/stack-overflow-teams/package.json
@@ -44,6 +44,7 @@
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.61",
+    "@mui/icons-material": "^7.1.0",
     "@mui/material": "5.16.14",
     "react-use": "^17.2.4"
   },

--- a/plugins/stack-overflow-teams/src/api/StackOverflowAPI.ts
+++ b/plugins/stack-overflow-teams/src/api/StackOverflowAPI.ts
@@ -27,6 +27,7 @@ export interface StackOverflowAPI {
   completeAuth(code: string, state: string): Promise<void>;
   getAuthStatus: () => Promise<boolean>;
   logout: () => Promise<boolean>;
+  submitAccessToken: (token: string) => Promise<boolean>;
 }
 
 export const createStackOverflowApi = (
@@ -93,6 +94,14 @@ export const createStackOverflowApi = (
     logout: async (): Promise<boolean> => {
       try {
         await requestAPI('logout', 'POST');
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    submitAccessToken: async (token: string): Promise<boolean> => {
+      try {
+        await requestAPI('auth/token', 'POST', { accessToken: token });
         return true;
       } catch {
         return false;

--- a/plugins/stack-overflow-teams/src/api/StackOverflowAPI.ts
+++ b/plugins/stack-overflow-teams/src/api/StackOverflowAPI.ts
@@ -13,6 +13,7 @@ type ApiResponse<T> = PaginatedResponse<T>;
 
 interface BaseUrlResponse {
   SOInstance: string;
+  teamName: string
 }
 
 export interface StackOverflowAPI {
@@ -22,6 +23,7 @@ export interface StackOverflowAPI {
   getUsers(): Promise<ApiResponse<User>>;
   getMe(): Promise<User>;
   getBaseUrl(): Promise<string>;
+  getTeamName(): Promise<string>;
   postQuestion(title: string, body: string, tags: string[]): Promise<Question>;
   startAuth(): Promise<string>;
   completeAuth(code: string, state: string): Promise<void>;
@@ -70,6 +72,10 @@ export const createStackOverflowApi = (
     getBaseUrl: async () => {
       const response = await requestAPI<BaseUrlResponse>('baseurl');
       return response.SOInstance;
+    },
+    getTeamName: async () => {
+      const response = await requestAPI<BaseUrlResponse>('baseurl')
+      return response.teamName
     },
     postQuestion: (title: string, body: string, tags: string[]) =>
       requestAPI<Question>('questions', 'POST', { title, body, tags }),

--- a/plugins/stack-overflow-teams/src/components/StackOverflowAuth/StackAuthStart.tsx
+++ b/plugins/stack-overflow-teams/src/components/StackOverflowAuth/StackAuthStart.tsx
@@ -212,6 +212,7 @@ export const StackOverflowAuthStart = () => {
                 fullWidth
                 onClick={handleTokenSubmit}
                 disabled={isSubmitting || !accessToken.trim()}
+                className={classes.button}
               >
                 {isSubmitting ? 'Validating...' : 'Submit Token'}
               </Button>

--- a/plugins/stack-overflow-teams/src/components/StackOverflowAuth/StackAuthStart.tsx
+++ b/plugins/stack-overflow-teams/src/components/StackOverflowAuth/StackAuthStart.tsx
@@ -24,15 +24,15 @@ export const StackOverflowAuthStart = () => {
   const [showToken, setShowToken] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [tokenSuccess, setTokenSuccess] = useState<boolean>(false);
-  const [baseUrl, setBaseUrl] = useState<string | null>(null);
+  const [teamName, setTeamName] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    const fetchBaseUrl = async () => {
+    const fetchTeamName = async () => {
       try {
         setIsLoading(true);
-        const baseUrlValue = await stackOverflowTeamsApi.getBaseUrl();
-        setBaseUrl(baseUrlValue);
+        const teamNameValue = await stackOverflowTeamsApi.getTeamName();
+        setTeamName(teamNameValue);
       } catch (error) {
         setAuthError('Failed to fetch Stack Overflow instance information.');
       } finally {
@@ -40,11 +40,11 @@ export const StackOverflowAuthStart = () => {
       }
     };
 
-    fetchBaseUrl();
+    fetchTeamName();
   }, [stackOverflowTeamsApi]);
 
-  // Determine if user is on basic or business plan based on the baseUrl
-  const isBasicOrBusinessPlan = baseUrl === 'https://api.stackoverflowteams.com';
+  // Determine if user is on basic or business plan based on the teamName
+  const isBasicOrBusinessPlan = Boolean(teamName)
 
   const handleAuth = async () => {
     try {

--- a/plugins/stack-overflow-teams/src/components/StackOverflowAuth/StackAuthStart.tsx
+++ b/plugins/stack-overflow-teams/src/components/StackOverflowAuth/StackAuthStart.tsx
@@ -1,15 +1,50 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useApi } from '@backstage/core-plugin-api';
 import { stackoverflowteamsApiRef } from '../../api';
-// eslint-disable-next-line no-restricted-imports
-import { Button, Typography, Box } from '@mui/material';
-import { useStackOverflowStyles } from '../StackOverflow/hooks'; // Import the styles hook
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import Paper from '@mui/material/Paper';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import Link from '@mui/material/Link';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import { useStackOverflowStyles } from '../StackOverflow/hooks';
 import { StackOverflowIcon } from '../../icons';
 
 export const StackOverflowAuthStart = () => {
   const stackOverflowTeamsApi = useApi(stackoverflowteamsApiRef);
   const classes = useStackOverflowStyles();
   const [authError, setAuthError] = useState<string | null>(null);
+  const [accessToken, setAccessToken] = useState<string>('');
+  const [showToken, setShowToken] = useState<boolean>(false);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [tokenSuccess, setTokenSuccess] = useState<boolean>(false);
+  const [baseUrl, setBaseUrl] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const fetchBaseUrl = async () => {
+      try {
+        setIsLoading(true);
+        const baseUrlValue = await stackOverflowTeamsApi.getBaseUrl();
+        setBaseUrl(baseUrlValue);
+      } catch (error) {
+        setAuthError('Failed to fetch Stack Overflow instance information.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchBaseUrl();
+  }, [stackOverflowTeamsApi]);
+
+  // Determine if user is on basic or business plan based on the baseUrl
+  const isBasicOrBusinessPlan = baseUrl === 'https://api.stackoverflowteams.com';
 
   const handleAuth = async () => {
     try {
@@ -17,9 +52,55 @@ export const StackOverflowAuthStart = () => {
       const authUrl = await stackOverflowTeamsApi.startAuth();
       window.location.href = authUrl;
     } catch (error) {
-      setAuthError('Something went wrong during authentication. Please try again.');
+      setAuthError(
+        'Something went wrong during authentication. Please try again.',
+      );
     }
   };
+
+  const handleTokenSubmit = async () => {
+    if (!accessToken.trim()) {
+      setAuthError('Access token cannot be empty');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setAuthError(null);
+
+    try {
+      const success = await stackOverflowTeamsApi.submitAccessToken(
+        accessToken,
+      );
+
+      if (success) {
+        setTokenSuccess(true);
+        setAccessToken('');
+        window.location.reload();
+      } else {
+        setAuthError(
+          'Failed to validate token. Please check your token and try again.',
+        );
+      }
+    } catch (error) {
+      setAuthError('Network error. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        height="100vh"
+      >
+        <Typography variant="body1">Loading Stack Overflow configuration...</Typography>
+      </Box>
+    );
+  }
 
   return (
     <Box
@@ -30,34 +111,134 @@ export const StackOverflowAuthStart = () => {
       height="100vh"
       bgcolor="background.default"
     >
-      <StackOverflowIcon />
-      <Typography variant="h6">Stack Overflow for Teams Login</Typography>
-      <Box mt={1}>
-      <Typography variant="body1" color="textSecondary" >
-        Click the button below to log in with your Stack Overflow for Teams
-        account.
-      </Typography>
-      </Box>
-      <Box mt={2}>
-      <Button
-        variant="contained"
-        className={classes.button}
-        onClick={handleAuth}
+      <Paper
+        elevation={3}
+        sx={{
+          padding: 4,
+          width: '100%',
+          maxWidth: '500px',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
       >
-        Login with Stack Overflow
-      </Button>
-      </Box>
-
-      {authError && (
-        <Typography 
-          variant="body2" 
-          color="error" 
-          mt={2}
-          sx={{ maxWidth: '300px', textAlign: 'center' }}
-        >
-          {authError}
+        <StackOverflowIcon />
+        <Typography variant="h5" gutterBottom>
+          Stack Overflow for Teams
         </Typography>
-      )}
+
+        {/* Standard OAuth login - only displayed if NOT on basic/business plan */}
+        {!isBasicOrBusinessPlan && (
+          <Box width="100%" mb={3}>
+            <Typography
+              variant="body1"
+              color="textSecondary"
+              align="center"
+              gutterBottom
+            >
+              Connect with your Stack Overflow for Enterprise account
+            </Typography>
+
+            <Box mt={2} display="flex" justifyContent="center">
+              <Button
+                variant="contained"
+                className={classes.button}
+                onClick={handleAuth}
+                disabled={isSubmitting}
+                fullWidth
+              >
+                Login with Stack Overflow
+              </Button>
+            </Box>
+          </Box>
+        )}
+
+        {/* Manual PAT token input for basic/business plans */}
+        {isBasicOrBusinessPlan && (
+          <Box width="100%">
+            <Typography
+              variant="body1"
+              color="textSecondary"
+              align="center"
+              gutterBottom
+            >
+              Enter your Personal Access Token (PAT)
+            </Typography>
+
+            <Typography
+              variant="body2"
+              color="textSecondary"
+              align="center"
+              gutterBottom
+            >
+              <Link
+                href="https://stackoverflowteams.help/en/articles/10908790-personal-access-tokens-pats-for-api-authentication"
+                target="_blank"
+                rel="noopener noreferrer"
+                color="primary"
+              >
+                Learn how to generate a Personal Access Token
+              </Link>
+            </Typography>
+
+            <TextField
+              fullWidth
+              label="Personal Access Token"
+              variant="outlined"
+              margin="normal"
+              value={accessToken}
+              onChange={e => setAccessToken(e.target.value)}
+              type={showToken ? 'text' : 'password'}
+              disabled={isSubmitting}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      aria-label="toggle token visibility"
+                      onClick={() => setShowToken(!showToken)}
+                      edge="end"
+                    >
+                      {showToken ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+
+            <Box mt={2}>
+              <Button
+                variant="contained"
+                color="primary"
+                fullWidth
+                onClick={handleTokenSubmit}
+                disabled={isSubmitting || !accessToken.trim()}
+              >
+                {isSubmitting ? 'Validating...' : 'Submit Token'}
+              </Button>
+            </Box>
+          </Box>
+        )}
+        {authError && (
+          <Typography
+            variant="body2"
+            color="error"
+            sx={{ maxWidth: '100%', textAlign: 'center', mt: 2 }}
+          >
+            {authError}
+          </Typography>
+        )}
+      </Paper>
+
+      <Snackbar
+        open={tokenSuccess}
+        autoHideDuration={6000}
+        onClose={() => setTokenSuccess(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="success" variant="filled">
+          Stack Overflow token accepted successfully!
+        </Alert>
+      </Snackbar>
     </Box>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,6 +2712,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/runtime@npm:7.27.1"
+  checksum: 10c0/530a7332f86ac5a7442250456823a930906911d895c0b743bf1852efc88a20a016ed4cd26d442d0ca40ae6d5448111e02a08dd638a4f1064b47d080e2875dc05
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.25.9, @babel/template@npm:^7.3.3":
   version: 7.25.9
   resolution: "@babel/template@npm:7.25.9"
@@ -9412,6 +9419,22 @@ __metadata:
   version: 5.16.14
   resolution: "@mui/core-downloads-tracker@npm:5.16.14"
   checksum: 10c0/eb866003ee4564c40423aadc4513b4c7d72c69723fe7dee4697ac70c19951e6e11093bb190761dc51a8f4d2731e562034ecb284930eec931bae1a56b8e18ca60
+  languageName: node
+  linkType: hard
+
+"@mui/icons-material@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "@mui/icons-material@npm:7.1.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.27.1"
+  peerDependencies:
+    "@mui/material": ^7.1.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/d83c5a1506526525fa93053b4ecd4ff498236a415f7594e75252fbec7e4584bb8470db3e04198a4924e8bd67af96cbaf93a9dee0f0ef9fa19a999bd6ade01734
   languageName: node
   linkType: hard
 
@@ -16126,6 +16149,7 @@ __metadata:
     "@types/jsonwebtoken": "npm:^9"
     "@types/qs": "npm:^6"
     "@types/supertest": "npm:^2.0.12"
+    csrf: "npm:^3.1.0"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     jsonwebtoken: "npm:^9.0.2"
@@ -16153,6 +16177,7 @@ __metadata:
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"
+    "@mui/icons-material": "npm:^7.1.0"
     "@mui/material": "npm:5.16.14"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^14.0.0"
@@ -17994,6 +18019,17 @@ __metadata:
     randombytes: "npm:^2.1.0"
     randomfill: "npm:^1.0.4"
   checksum: 10c0/184a2def7b16628e79841243232ab5497f18d8e158ac21b7ce90ab172427d0a892a561280adc08f9d4d517bce8db2a5b335dc21abb970f787f8e874bd7b9db7d
+  languageName: node
+  linkType: hard
+
+"csrf@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "csrf@npm:3.1.0"
+  dependencies:
+    rndm: "npm:1.2.0"
+    tsscmp: "npm:1.0.6"
+    uid-safe: "npm:2.1.5"
+  checksum: 10c0/9cbc308352d481130d98b7826e447861560e6d09b4629591f9c31e6832f8f338540e2f5be00fc1945f752f549a1bc17954e932e4a8dfc325be41e695dfc63b6a
   languageName: node
   linkType: hard
 
@@ -30520,6 +30556,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rndm@npm:1.2.0":
+  version: 1.2.0
+  resolution: "rndm@npm:1.2.0"
+  checksum: 10c0/31788f9a07659b8b13e03c3d68bfa0cf7aab811edca10ba823841db4e830ca7d7eae8decc8cfcb334bc0e974c5022dcd6a1fb9ffd72dac8fa3efa45a4f8bdde5
+  languageName: node
+  linkType: hard
+
 "roarr@npm:^2.15.3":
   version: 2.15.4
   resolution: "roarr@npm:2.15.4"
@@ -33311,7 +33354,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uid-safe@npm:~2.1.5":
+"uid-safe@npm:2.1.5, uid-safe@npm:~2.1.5":
   version: 2.1.5
   resolution: "uid-safe@npm:2.1.5"
   dependencies:


### PR DESCRIPTION
Due to the nature of our products, the basic and business tiers cannot use OAuth; only Enterprise has such a feature.

As a workaround, I will allow the manual input of individual PAT Tokens for Basic and Business users. These tokens only need to be provided once and will work for as long as they have set the token's expiration.

The integration will detect, depending on the configuration, whether to allow providing PAT manually or use OAuth.