### PR TITLE
chore: we'll now retrieve questions and tags by creationDate

### DIFF
--- a/plugins/search-backend-module-stack-overflow-teams-collator/src/collators/StackOverflowQuestionsCollatorFactory.ts
+++ b/plugins/search-backend-module-stack-overflow-teams-collator/src/collators/StackOverflowQuestionsCollatorFactory.ts
@@ -99,7 +99,7 @@ export class StackOverflowQuestionsCollatorFactory
     // See https://api.stackexchange.com/docs/questions
     this.requestParams = {
       order: 'desc',
-      sort: 'activity',
+      sort: 'creation',
       ...(options.requestParams ?? {}),
     };
   }

--- a/plugins/stack-overflow-teams-backend/src/api/createStackOverflowApi.ts
+++ b/plugins/stack-overflow-teams-backend/src/api/createStackOverflowApi.ts
@@ -6,7 +6,8 @@ export const createStackOverflowApi = (baseUrl: string) => {
     teamName?: string,
     body?: any,
     searchQuery?: string,
-    pageSize?: number
+    pageSize?: number,
+    additionalParams?: Record<string, string>
   ): Promise<T> => {
     let url = teamName
       ? `${baseUrl}/v3/teams/${teamName}${endpoint}`
@@ -20,6 +21,12 @@ export const createStackOverflowApi = (baseUrl: string) => {
 
     if (pageSize) {
       queryParams.append('pageSize', pageSize.toString());
+    }
+
+    if (additionalParams) {
+      Object.entries(additionalParams).forEach(([key, value]) => {
+        queryParams.append(key, value);
+      });
     }
 
     if (queryParams.toString()) {
@@ -49,8 +56,8 @@ export const createStackOverflowApi = (baseUrl: string) => {
   };
 
   return {
-    GET: <T>(endpoint: string, authToken: string, teamName?: string) =>
-      request<T>(endpoint, 'GET', authToken, teamName),
+    GET: <T>(endpoint: string, authToken: string, teamName?: string, additionalParams?: Record<string, string>) =>
+      request<T>(endpoint, 'GET', authToken, teamName, undefined, undefined, undefined, additionalParams),
 
     POST: <T>(endpoint: string, body: any, authToken: string, teamName?: string) =>
       request<T>(endpoint, 'POST', authToken, teamName, body),

--- a/plugins/stack-overflow-teams-backend/src/services/StackOverflowService/createStackOverflowService.ts
+++ b/plugins/stack-overflow-teams-backend/src/services/StackOverflowService/createStackOverflowService.ts
@@ -35,9 +35,9 @@ export async function createStackOverflowService({
   return {
     // GET
     getQuestions: authToken =>
-      api.GET<PaginatedResponse<Question>>('/questions', authToken, teamName),
+      api.GET<PaginatedResponse<Question>>('/questions', authToken, teamName, { sort: 'creation', order: 'desc' }),
     getTags: authToken =>
-      api.GET<PaginatedResponse<Tag>>('/tags', authToken, teamName),
+      api.GET<PaginatedResponse<Tag>>('/tags', authToken, teamName, { sort: 'creationDate', order: 'desc'}),
     getUsers: authToken =>
       api.GET<PaginatedResponse<User>>('/users', authToken, teamName),
     getMe: authToken => api.GET<User>('/users/me', authToken, teamName),

--- a/plugins/stack-overflow-teams/src/components/StackOverflow/StackOverflowPosts.tsx
+++ b/plugins/stack-overflow-teams/src/components/StackOverflow/StackOverflowPosts.tsx
@@ -102,7 +102,7 @@ export const StackOverflowQuestions = () => {
   const [baseUrl, setBaseUrl] = useState<string>('');
   const { data, loading, error } = useStackOverflowData('questions');
   const [searchTerm, setSearchTerm] = useState('');
-  const [activeFilter, setActiveFilter] = useState<string | null>(null);
+  const [activeFilter, setActiveFilter] = useState<string | null>('active');
   const [currentPage, setCurrentPage] = useState(0);
 
   useEffect(() => {


### PR DESCRIPTION
I used to leave this without the param, under the impression that it would bring questions by the latest activity, but the behaviour was a bit weird on bigger instances. I've fixed this by keeping things explicit; questions and tags will come sorted by creation date. 

Additionally, the default filter for the Stack Overflow HUB will be the 'active' filter.